### PR TITLE
Suggestion: rename validator to verifier

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -76,8 +76,8 @@ pub mod platform_token {
     }
 
     pub trait FromPlatformJwt: Sized + DeserializeOwned {
-        fn from_platform_jwt(jwt: &str, validator: &dyn JwsVerifier) -> Result<Self, JwtError> {
-            let (payload, _) = josekit::jwt::decode_with_verifier(jwt, validator)?;
+        fn from_platform_jwt(jwt: &str, verifier: &dyn JwsVerifier) -> Result<Self, JwtError> {
+            let (payload, _) = josekit::jwt::decode_with_verifier(jwt, verifier)?;
             let claim = payload
                 .claim("payload")
                 .ok_or(JwtError::InvalidStructure("payload"))?;


### PR DESCRIPTION
The comment `Public key used to sign ID Contact JWSs` and the name `validator` caused some confusion to me. I think using `verifier` would be better. This change would require a version bump.